### PR TITLE
Update Index.html  - changed subheading to a catchier phrase

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
                         The Altening
                         </h1>
                         <h3>
-                            Minecraft Account Generator
+                            Who else wants to play Minecraft for free and be unbanned on their favorite servers?
                         </h3>
                         </div>
                         <button onclick="window.location.href='https://panel.thealtening.com';" class="round-button">


### PR DESCRIPTION
I've replaced "Minecraft Account Generator" subheading with "Who else wants to play Minecraft for free and be unbanned on their favorite servers?"

This shouldn't have much impact on SEO as it's already expresssed throughout the page, and we already rank very well for it. I was considering new topics throughout my continual research into copywriting and if you didn't like that particular phrase, here are some alternatives:

The Secret of playing Minecraft for Free and being unbanned on your favorite servers
Little knowns ways of playing Minecraft for Free and being unbanned on your favorite servers
Here's a quick way to play Minecraft for Free and get unbanned on your favorite servers
Now you can have Minecraft for Free and be unbanned on your favorite servers
feel free to pick which one you like best, it's all the same root sentence but with different forms of copywriting as a starter